### PR TITLE
Use elementsregtest and make default wallet rich

### DIFF
--- a/elements-harness/src/elementd_rpc.rs
+++ b/elements-harness/src/elementd_rpc.rs
@@ -60,6 +60,6 @@ mod test {
 
         let network = client.network().await.unwrap();
 
-        assert_eq!(network, "regtest")
+        assert_eq!(network, "elementsregtest")
     }
 }

--- a/elements-harness/src/image.rs
+++ b/elements-harness/src/image.rs
@@ -1,3 +1,4 @@
+use crate::ELEMENTSD_RPC_PORT;
 use hex::encode;
 use hmac::{Hmac, Mac, NewMac};
 use rand::{thread_rng, Rng};
@@ -104,6 +105,7 @@ pub struct ElementsCoreImageArgs {
     pub print_to_console: bool,
     pub tx_index: bool,
     pub rpc_bind: String,
+    pub rpc_port: Option<u16>,
     pub rpc_allowip: String,
     pub rpc_auth: RpcAuth,
     pub accept_non_std_txn: Option<bool>,
@@ -120,6 +122,7 @@ impl Default for ElementsCoreImageArgs {
             rpc_auth: RpcAuth::new(String::from("elements")),
             tx_index: true,
             rpc_bind: "0.0.0.0".to_string(), // This allows to bind on all ports
+            rpc_port: Some(ELEMENTSD_RPC_PORT),
             rpc_allowip: "0.0.0.0/0".to_string(),
             accept_non_std_txn: Some(false),
             rest: true,
@@ -143,7 +146,7 @@ impl IntoIterator for ElementsCoreImageArgs {
 
         match self.network {
             Network::Testnet => args.push("-testnet".to_string()),
-            Network::Regtest => args.push("-regtest".to_string()),
+            Network::Regtest => args.push("-chain=elementsregtest".to_string()),
             Network::Mainnet => {}
         }
 
@@ -157,6 +160,10 @@ impl IntoIterator for ElementsCoreImageArgs {
 
         if !self.rpc_bind.is_empty() {
             args.push(format!("-rpcbind={}", self.rpc_bind));
+        }
+
+        if let Some(rpc_port) = self.rpc_port {
+            args.push(format!("-rpcport={}", rpc_port));
         }
 
         if self.print_to_console {
@@ -182,6 +189,9 @@ impl IntoIterator for ElementsCoreImageArgs {
         }
 
         args.push("-debug".into());
+
+        // make the default wallet rich
+        args.push("-initialfreecoins=2100000000000000".into());
 
         args.into_iter()
     }


### PR DESCRIPTION
Initially I thought `regtest` is elements `regtest` mode but this seems to be wrong. Using a custom chain e.g. `elementsregtest` solves this problem. See here: https://docs.blockstream.com/liquid/node_setup.html

This seems to be the correct thing to do as the addresses generated in code by using something like this are accepted by the node.

```rust
        let secp = elements::bitcoin::secp256k1::Secp256k1::new();

        let (_private_key, public_key) =
            secp.generate_keypair(&mut elements::bitcoin::secp256k1::rand::thread_rng());
        let public_key = elements::bitcoin::PublicKey {
            compressed: true,
            key: public_key,
        };
        let target_address =
            elements::Address::p2wpkh(&public_key, None, &elements::AddressParams::ELEMENTS);

        let address_string = target_address.clone().to_string();
        println!("address : {}", address_string);
```