### PR TITLE
Fix linter errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,8 +1472,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb15d6255c792356a0f578d8a645c677904dc02e862bebe2ecc18e0c01b9a0ce"
+source = "git+https://github.com/seanmonstar/reqwest#541d0c2aba5d32368d33c87d89ebae63869961ad"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -1502,7 +1501,6 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-bindgen-test",
  "web-sys",
  "winreg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,6 @@
 [workspace]
 members = [ "elements-harness", "swap", "elements-fun", "elements-fun/fuzz", "waves/wallet", "bobtimus" ]
+
+[patch.crates-io]
+# Patch reqwest until this commit is released: https://github.com/seanmonstar/reqwest/commit/e7be3eda04ffff53adf9fcc52ea3e61b1ad9ccda
+reqwest = { git = "https://github.com/seanmonstar/reqwest" }

--- a/waves/.eslintignore
+++ b/waves/.eslintignore
@@ -1,0 +1,1 @@
+src/wallet/

--- a/waves/wallet/src/wallet.rs
+++ b/waves/wallet/src/wallet.rs
@@ -313,6 +313,7 @@ impl fmt::Display for ListOfWallets {
 mod tests {
     use super::*;
     use wasm_bindgen_test::*;
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     #[wasm_bindgen_test]
     pub async fn given_no_wallet_when_getting_address_then_fails() {


### PR DESCRIPTION
These linter errors prevented us from running `yarn build` once we actually include the WASM.