### PR TITLE
Change Bobtimus' API to accept an outpoint instead of TxIn and TxOut

### DIFF
--- a/bobtimus/src/bin/fake_bobtimus.rs
+++ b/bobtimus/src/bin/fake_bobtimus.rs
@@ -145,7 +145,7 @@ mod fixed_rate {
 mod tests {
     use super::*;
     use anyhow::{Context, Result};
-    use bobtimus::{Bobtimus, CreateSwapPayload, LatestRate, LiquidBtc};
+    use bobtimus::{AliceInput, Bobtimus, CreateSwapPayload, LatestRate, LiquidBtc};
     use elements_fun::{
         bitcoin::Amount, secp256k1::rand::thread_rng, Address, OutPoint, Transaction, TxOut,
     };
@@ -261,7 +261,13 @@ mod tests {
 
         let transaction = bob
             .handle_create_swap(CreateSwapPayload {
-                protocol_msg: message0,
+                alice_inputs: vec![AliceInput {
+                    outpoint: message0.input.previous_output,
+                    blinding_key: message0.input_blinding_sk,
+                }],
+                address_redeem: message0.address_redeem,
+                address_change: message0.address_change,
+                fee: message0.fee,
                 btc_amount: redeem_amount_bob,
             })
             .await

--- a/bobtimus/src/lib.rs
+++ b/bobtimus/src/lib.rs
@@ -1,13 +1,15 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use elements_fun::{
+    bitcoin::Amount,
     secp256k1::{
         rand::{CryptoRng, RngCore},
         SecretKey,
     },
-    AssetId, Transaction,
+    Address, AssetId, OutPoint, Transaction, TxIn,
 };
 use elements_harness::{elementd_rpc::ElementsRpc, Client as ElementsdClient};
+use futures::{stream::FuturesUnordered, TryStreamExt};
 use serde::Deserialize;
 use swap::states::{Bob0, Message0};
 
@@ -28,9 +30,18 @@ pub struct Bobtimus<R, RS> {
 
 #[derive(Deserialize)]
 pub struct CreateSwapPayload {
-    #[serde(flatten)]
-    pub protocol_msg: Message0,
+    pub alice_inputs: Vec<AliceInput>,
+    pub address_redeem: Address,
+    pub address_change: Address,
+    #[serde(with = "::elements_fun::bitcoin::util::amount::serde::as_sat")]
+    pub fee: Amount,
     pub btc_amount: LiquidBtc,
+}
+
+#[derive(Deserialize, Clone, Copy)]
+pub struct AliceInput {
+    pub outpoint: OutPoint,
+    pub blinding_key: SecretKey,
 }
 
 impl<R, RS> Bobtimus<R, RS> {
@@ -42,20 +53,29 @@ impl<R, RS> Bobtimus<R, RS> {
         R: RngCore + CryptoRng,
         RS: LatestRate,
     {
-        let latest_rate = self.rate_service.latest_rate().await?;
+        let latest_rate = self
+            .rate_service
+            .latest_rate()
+            .await
+            .context("failed to get latest rate")?;
         let usdt_amount = latest_rate.buy_quote(payload.btc_amount)?;
 
-        let inputs = self
+        let bob_inputs = self
             .elementsd
             .select_inputs_for(self.usdt_asset_id, usdt_amount.into(), true)
-            .await?;
+            .await
+            .context("failed to select inputs for swap")?;
 
-        let (input, input_blinding_sk) = match inputs.as_slice() {
+        let (input, input_blinding_sk) = match bob_inputs.as_slice() {
             [(outpoint, txout)] => {
                 use hmac::{Hmac, Mac, NewMac};
                 use sha2::Sha256;
 
-                let master_blinding_key = self.elementsd.dumpmasterblindingkey().await?;
+                let master_blinding_key = self
+                    .elementsd
+                    .dumpmasterblindingkey()
+                    .await
+                    .context("failed to dump master blinding key")?;
                 let master_blinding_key = hex::decode(master_blinding_key)?;
 
                 let mut mac = Hmac::<Sha256>::new_varkey(&master_blinding_key)
@@ -71,8 +91,16 @@ impl<R, RS> Bobtimus<R, RS> {
             _ => bail!("TODO: Support multiple inputs per party"),
         };
 
-        let redeem_address = self.elementsd.getnewaddress().await?;
-        let change_address = self.elementsd.getnewaddress().await?;
+        let redeem_address = self
+            .elementsd
+            .getnewaddress()
+            .await
+            .context("failed to get redeem address")?;
+        let change_address = self
+            .elementsd
+            .getnewaddress()
+            .await
+            .context("failed to get change address")?;
 
         let protocol_state = Bob0::new(
             usdt_amount.into(),
@@ -84,7 +112,67 @@ impl<R, RS> Bobtimus<R, RS> {
             change_address,
         );
 
-        let protocol_state = protocol_state.interpret(&mut self.rng, payload.protocol_msg)?;
+        let alice_inputs = payload
+            .alice_inputs
+            .iter()
+            .copied()
+            .map(
+                |AliceInput {
+                     outpoint,
+                     blinding_key,
+                 }| {
+                    let client = self.elementsd.clone();
+                    async move {
+                        let transaction = client
+                            .get_raw_transaction(outpoint.txid)
+                            .await
+                            .with_context(|| {
+                                format!("failed to fetch transaction {}", outpoint.txid)
+                            })?;
+
+                        let txin = TxIn {
+                            previous_output: outpoint,
+                            is_pegin: false,
+                            has_issuance: false,
+                            script_sig: Default::default(),
+                            sequence: 0,
+                            asset_issuance: Default::default(),
+                            witness: Default::default(),
+                        };
+                        let txin_as_txout = transaction
+                            .output
+                            .get(outpoint.vout as usize)
+                            .with_context(|| {
+                                format!(
+                                    "vout index {} is not valid for transaction {}",
+                                    outpoint.vout, outpoint.txid
+                                )
+                            })?
+                            .clone();
+
+                        Result::<_, anyhow::Error>::Ok((txin, txin_as_txout, blinding_key))
+                    }
+                },
+            )
+            .collect::<FuturesUnordered<_>>()
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let (input, input_as_txout, input_blinding_sk) = alice_inputs
+            .get(0)
+            .context("alice needs to send at least one input")?
+            .clone();
+
+        let message0 = Message0 {
+            input,
+            input_as_txout,
+            input_blinding_sk,
+            address_redeem: payload.address_redeem,
+            address_change: payload.address_change,
+            fee: payload.fee,
+        };
+
+        let protocol_state = protocol_state.interpret(&mut self.rng, message0)?;
         let tx = self
             .elementsd
             .sign_raw_transaction(protocol_state.unsigned_transaction())

--- a/bobtimus/src/lib.rs
+++ b/bobtimus/src/lib.rs
@@ -159,7 +159,7 @@ impl<R, RS> Bobtimus<R, RS> {
             .await?;
 
         let (input, input_as_txout, input_blinding_sk) = alice_inputs
-            .get(0)
+            .get(0) // TODO: Handle multiple inputs from Alice
             .context("alice needs to send at least one input")?
             .clone();
 


### PR DESCRIPTION
Bobtimus can easily query the blockchain for all data it needs, hence
we can reduce bandwidth usage and simplify client implementations.