### PR TITLE
Add build matrix for 'normal' tests to also build on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,15 @@ jobs:
           path: ./elements-fun/fuzz/hfuzz_workspace
 
   build_test_workspace:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [ x86_64-unknown-linux-gnu, x86_64-apple-darwin ]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -90,10 +98,15 @@ jobs:
         uses: actions/cache@v1
         with:
           path: target
-          key: target-directory-${{ hashFiles('Cargo.lock') }}-v1
+          key: ${{ matrix.os }}-target-directory-${{ hashFiles('Cargo.lock') }}-v1
 
-      - name: Cargo test
+      - name: Cargo test (all workspace)
+        if: matrix.os == 'ubuntu-latest'
         run: cargo test --workspace --all-features
+
+      - name: Cargo build (all workspace without elements-fuzz )
+        if: matrix.os == 'macos-latest'
+        run: cargo build --workspace --exclude elements-fuzz --all-features
 
   swap_wasm:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-zkp"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/rust-secp256k1-zkp#1ee2d80363f9971d4988ebe2e33bb30113b816c3"
+source = "git+https://github.com/comit-network/rust-secp256k1-zkp#7397ca919b0097c73c808c7cb02f15f7716a4b0d"
 dependencies = [
  "bitcoin_hashes 0.9.4",
  "rand 0.6.5",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-zkp-sys"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/rust-secp256k1-zkp#1ee2d80363f9971d4988ebe2e33bb30113b816c3"
+source = "git+https://github.com/comit-network/rust-secp256k1-zkp#7397ca919b0097c73c808c7cb02f15f7716a4b0d"
 dependencies = [
  "cc",
  "secp256k1-sys",


### PR DESCRIPTION
Let's see what CI says about macos builds

Once: https://github.com/comit-network/rust-secp256k1-zkp/pull/8 was merged this PR should turn green.

We only build on MacOS and don't run tests because some tests require docker. See https://github.com/comit-network/droplet/issues/55