### PR TITLE
Upload hfuzz_workspace in case the fuzzer fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,13 @@ jobs:
           cd ./elements-fun/fuzz
           ./fuzz.sh
 
+      - name: Upload fuzz workspace on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: fuzz-workspace
+          path: ./elements-fun/fuzz/hfuzz_workspace
+
   build_test_workspace:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
In order to debug the fuzzer locally, once has to load the crash
file in the debugger. As such, we upload the whole fuzzer workspace
as an artefact so it can be downloaded from the CI job.

Fixes #52.