### PR TITLE
Disable cache on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
           override: true
 
       - name: Cache target directory
+        if: ${{ matrix.os }} != 'macos-latest' # Need to disable cache until https://github.com/actions/cache/issues/403 is fixed.
         uses: actions/cache@v2
         with:
           path: target


### PR DESCRIPTION
FYI @bonomat 

We need to disable the cache because MacOS `tar` is broken :(