### PR TITLE
Replace `Lazy` statics with constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,37 @@ jobs:
           yarn run build
           yarn run test
 
+  wallet_buildscript_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+
+      - name: Cache target directory
+        if: matrix.os != 'macos-latest' # Need to disable cache until https://github.com/actions/cache/issues/403 is fixed.
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ matrix.os }}-target-directory-${{ hashFiles('Cargo.lock') }}-v1
+
+      - name: Build wallet with default configuration
+        run: cargo test -p wallet constants_tests
+
+      - name: Build wallet with custom configuration
+        run: cargo test -p wallet constants_tests
+        env:
+          NATIVE_ASSET_TICKER: FOO-BTC
+          NATIVE_ASSET_ID: 2dcf5a8834645654911964ec3602426fd3b9b4017554d3f9c19403e7fc1411d3
+          ESPLORA_URL: http://localhost:3000/
+          ELEMENTS_CHAIN: ELEMENTS
+          DEFAULT_FEE_PER_VBYTE: 13.37
+
   wasm_wallet_test:
     runs-on: ubuntu-latest
     steps:

--- a/elements-fun/src/issuance.rs
+++ b/elements-fun/src/issuance.rs
@@ -90,6 +90,14 @@ impl AssetId {
         Self::from(fast_merkle_root(&[entropy.into_inner(), ZERO32]))
     }
 
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(sha256::Midstate(bytes))
+    }
+
+    pub const fn into_bytes(self) -> [u8; 32] {
+        (self.0).0
+    }
+
     /// Calculate the reissuance token asset ID from the asset entropy.
     pub fn reissuance_token_from_entropy(entropy: sha256::Midstate, confidential: bool) -> Self {
         // H_a : asset reissuance tag

--- a/waves/wallet/Cargo.toml
+++ b/waves/wallet/Cargo.toml
@@ -39,6 +39,11 @@ web-sys = { version = "0.3", features = [ "Window", "Storage", "Cache", "CacheSt
 wee_alloc = { version = "0.4", optional = true } # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
+
+[build-dependencies]
+anyhow = "1"
+elements-fun = { path = "../../elements-fun" }
+
 # By default wasm-opt is true which makes the build fail.
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/waves/wallet/build.rs
+++ b/waves/wallet/build.rs
@@ -1,0 +1,54 @@
+use anyhow::{bail, Context, Result};
+use elements_fun::AssetId;
+use std::{env, fs, path::Path};
+
+fn main() -> Result<()> {
+    let out_dir = env::var_os("OUT_DIR").context("unable to access OUT_DIR")?;
+    let constants_rs = Path::new(&out_dir).join("constants.rs");
+
+    let native_asset_ticker = option_env!("NATIVE_ASSET_TICKER").unwrap_or("L-BTC");
+
+    let asset_id = option_env!("NATIVE_ASSET_ID")
+        .unwrap_or("6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d");
+    let native_asset_id = asset_id
+        .parse::<AssetId>()
+        .with_context(|| format!("failed to parse {} as asset id", asset_id))?;
+
+    let elements_esplora_url = option_env!("ESPLORA_URL")
+        .as_deref()
+        .unwrap_or("https://blockstream.info/liquid/api");
+
+    let address_params = match option_env!("ELEMENTS_CHAIN") {
+        None | Some("LIQUID") => "&elements_fun::AddressParams::LIQUID",
+        Some("ELEMENTS") => "&elements_fun::AddressParams::ELEMENTS",
+        Some(chain) => bail!("unsupported elements chain {}", chain),
+    };
+
+    let rate = option_env!("DEFAULT_SAT_PER_VBYTE")
+        .as_deref()
+        .unwrap_or("1.0");
+    let rate = rate
+        .parse::<f64>()
+        .with_context(|| format!("failed to parse '{}' as f64", rate))?;
+
+    fs::write(
+        &constants_rs,
+        &format!(
+            r#"
+pub const NATIVE_ASSET_TICKER: &str = "{}";
+pub const NATIVE_ASSET_ID: elements_fun::AssetId = elements_fun::AssetId::from_bytes({:?});
+pub const ELEMENTS_ESPLORA_URL: &str = "{}";
+pub const ADDRESS_PARAMS: &elements_fun::AddressParams = {};
+pub const DEFAULT_SAT_PER_VBYTE: f32 = {:.4};
+"#,
+            native_asset_ticker,
+            native_asset_id.into_bytes(),
+            elements_esplora_url,
+            address_params,
+            rate
+        ),
+    )
+    .context("failed to write constants.rs file")?;
+
+    Ok(())
+}

--- a/waves/wallet/src/esplora.rs
+++ b/waves/wallet/src/esplora.rs
@@ -1,17 +1,10 @@
-use crate::cache_storage::CacheStorage;
+use crate::{cache_storage::CacheStorage, constants::ELEMENTS_ESPLORA_URL};
 use anyhow::{anyhow, bail, Context, Result};
-use conquer_once::Lazy;
 use elements_fun::{
     encode::{deserialize, serialize_hex},
     Address, AssetId, BlockHash, Transaction, Txid,
 };
 use reqwest::StatusCode;
-
-static ELEMENTS_ESPLORA_URL: Lazy<&str> = Lazy::new(|| {
-    option_env!("ESPLORA_URL")
-        .as_deref()
-        .unwrap_or("https://blockstream.info/liquid/api")
-});
 
 /// Fetch the UTXOs of an address.
 ///

--- a/waves/wallet/src/wallet/make_create_swap_payload.rs
+++ b/waves/wallet/src/wallet/make_create_swap_payload.rs
@@ -32,7 +32,7 @@ pub async fn make_create_swap_payload(
                 };
                 let candidate_asset = unblinded_txout.asset;
 
-                if candidate_asset == *NATIVE_ASSET_ID {
+                if candidate_asset == NATIVE_ASSET_ID {
                     Some(coin_selection::Utxo {
                         outpoint,
                         value: unblinded_txout.value,
@@ -59,7 +59,7 @@ pub async fn make_create_swap_payload(
 
     let fee_estimates = map_err_from_anyhow!(esplora::get_fee_estimates().await)?;
 
-    let chosen_fee_rate = fee_estimates.b_6.unwrap_or(*DEFAULT_SAT_PER_VBYTE);
+    let chosen_fee_rate = fee_estimates.b_6.unwrap_or(DEFAULT_SAT_PER_VBYTE);
 
     let fee_for_our_output = (avg_vbytes::OUTPUT as f32 * chosen_fee_rate) as u64;
     let output = map_err_from_anyhow!(coin_select(

--- a/waves/wallet/src/wallet/withdraw_everything_to.rs
+++ b/waves/wallet/src/wallet/withdraw_everything_to.rs
@@ -69,7 +69,7 @@ pub async fn withdraw_everything_to(
 
     let fee = (estimated_virtual_size as f32
         * fee_estimates.b_6.unwrap_or_else(|| {
-            let default_fee_rate = *DEFAULT_SAT_PER_VBYTE;
+            let default_fee_rate = DEFAULT_SAT_PER_VBYTE;
             log::info!(
                 "fee estimate for block target '6' unavailable, falling back to default fee {}",
                 default_fee_rate
@@ -91,7 +91,7 @@ pub async fn withdraw_everything_to(
             // calculate the total amount we want to spend for this asset
             // if this is the native asset, subtract the fee
             let total_input = txouts.iter().map(|(_, _, txout)| txout.value).sum::<u64>();
-            let to_spend = if asset == *NATIVE_ASSET_ID {
+            let to_spend = if asset == NATIVE_ASSET_ID {
                 log::debug!(
                     "{} is the native asset, subtracting a fee of {} from it",
                     asset,
@@ -148,7 +148,7 @@ pub async fn withdraw_everything_to(
     // build transaction from grouped txouts
     let mut transaction = match txouts_grouped_by_asset.as_slice() {
         [] => return Err(JsValue::from_str("no balances in wallet")),
-        [(asset, _, _, _)] if asset != &*NATIVE_ASSET_ID => {
+        [(asset, _, _, _)] if asset != &NATIVE_ASSET_ID => {
             return Err(JsValue::from_str(&format!(
                 "cannot spend from wallet without native asset {} because we cannot pay a fee",
                 NATIVE_ASSET_TICKER


### PR DESCRIPTION
We add a buildscript that reads the env variables, verifies them and
writes them to a Rust file as constants which we can include at
build time.

This allows us to verify all the configuration parameters at build time
instead of being surprised at runtime with an error like
"invalid elements chain".