### PR TITLE
Replace `group_by` with `into_group_map`

### DIFF
--- a/waves/wallet/src/wallet/get_balances.rs
+++ b/waves/wallet/src/wallet/get_balances.rs
@@ -103,9 +103,9 @@ where
             }
             TxOut::Null(_) => None,
         })
-        .group_by(|(asset, _)| *asset);
+        .into_group_map();
 
-    (&grouped_txouts)
+    grouped_txouts
         .into_iter()
         .map(|(asset, utxos)| async move {
             let ad = match asset_resolver(asset).await {
@@ -116,7 +116,7 @@ where
                     AssetDescription::default(asset)
                 }
             };
-            let total_sum = utxos.map(|(_, value)| value).sum();
+            let total_sum = utxos.into_iter().sum();
 
             BalanceEntry::for_asset(total_sum, ad, native_asset_ticker)
         })

--- a/waves/wallet/src/wallet/withdraw_everything_to.rs
+++ b/waves/wallet/src/wallet/withdraw_everything_to.rs
@@ -80,14 +80,10 @@ pub async fn withdraw_everything_to(
 
     let txouts_grouped_by_asset = txouts
         .into_iter()
-        .group_by(|(_, _, unblinded)| unblinded.asset);
-
-    // prepare the data exactly as we need it to create the transaction
-    let txouts_grouped_by_asset = (&txouts_grouped_by_asset)
+        .map(|(utxo, confidential, unblinded)| (unblinded.asset, (utxo, confidential, unblinded)))
+        .into_group_map()
         .into_iter()
         .map(|(asset, txouts)| {
-            let txouts = txouts.collect::<Vec<_>>();
-
             // calculate the total amount we want to spend for this asset
             // if this is the native asset, subtract the fee
             let total_input = txouts.iter().map(|(_, _, txout)| txout.value).sum::<u64>();


### PR DESCRIPTION
`group_by` only groups "on-the-fly" and therefore does not work if
the iterator is not yet sorted.

`into_group_map` consumes the iterator instead and actually groups
all elements properly.