### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,8 +181,7 @@ checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 [[package]]
 name = "bitcoin"
 version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aefc9be9f17185f4ebccae6575d342063f775924d57df0000edb1880c0fb7095"
+source = "git+https://github.com/thomaseizinger/rust-bitcoin?branch=secp-0.20-rust-bitcoin-0.25.2#3751b736f28c9960bb8a8172e29fe0a2688bb868"
 dependencies = [
  "bech32",
  "bitcoin_hashes 0.9.4",
@@ -1597,7 +1596,8 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.10.10"
-source = "git+https://github.com/seanmonstar/reqwest#5099192b92df49f5fe7794b0112ec0f3a0a58ca7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -1789,8 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.19.0"
-source = "git+https://github.com/rust-bitcoin/rust-secp256k1#11e9641d21c861ef33272bdde7bf01bec73e4e7d"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfd0eece5bc8fca7ca07a0c17ffd334b028f72ffbe9dd8ec924a8c885753278"
 dependencies = [
  "bitcoin_hashes 0.9.4",
  "rand 0.6.5",
@@ -1800,8 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.3.1"
-source = "git+https://github.com/rust-bitcoin/rust-secp256k1#11e9641d21c861ef33272bdde7bf01bec73e4e7d"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e4b6455ee49f5901c8985b88f98fb0a0e1d90a6661f5a03f4888bd987dad29"
 dependencies = [
  "cc",
 ]
@@ -1809,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-zkp"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/rust-secp256k1-zkp#7397ca919b0097c73c808c7cb02f15f7716a4b0d"
+source = "git+https://github.com/comit-network/rust-secp256k1-zkp#73526ee20b8448ab5eaa36eee656cf6bc9e4a96a"
 dependencies = [
  "bitcoin_hashes 0.9.4",
  "rand 0.6.5",
@@ -1821,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-zkp-sys"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/rust-secp256k1-zkp#7397ca919b0097c73c808c7cb02f15f7716a4b0d"
+source = "git+https://github.com/comit-network/rust-secp256k1-zkp#73526ee20b8448ab5eaa36eee656cf6bc9e4a96a"
 dependencies = [
  "cc",
  "secp256k1-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,7 @@
 members = [ "elements-harness", "swap", "elements-fun", "elements-fun/fuzz", "waves/wallet", "bobtimus" ]
 
 [patch.crates-io]
-# Patch reqwest until this commit is released: https://github.com/seanmonstar/reqwest/commit/e7be3eda04ffff53adf9fcc52ea3e61b1ad9ccda
-reqwest = { git = "https://github.com/seanmonstar/reqwest" }
 # Until bdk depends on a version of rust-miniscript (likely v4.1) that includes this commit: https://github.com/rust-bitcoin/rust-miniscript/commit/f43f7e6edd06ac659500eb8177ef300e49affe92
 miniscript = { git = "https://github.com/coblox/rust-miniscript", branch = "wasm-bdk" }
-secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1" } # need to use latest HEAD until rust-secp256k1-zkp depends on a released version
+# Until next version with secp256k1 0.20 is released. This purposely points to a branch that backports this change to the 0.25.2 tag to avoid compilation errors in miniscript.
+bitcoin = { git = "https://github.com/thomaseizinger/rust-bitcoin", branch = "secp-0.20-rust-bitcoin-0.25.2" }

--- a/elements-fun/Cargo.toml
+++ b/elements-fun/Cargo.toml
@@ -20,7 +20,7 @@ bitcoin = { version = "0.25", features = [ "rand" ] }
 bitcoin_hashes = "0.9.0" # While this dependency is included in bitcoin, we need this to use the macros.
 hex = "0.4.2"
 libc = "0.2.69"
-secp256k1 = { version = "0.19.0", features = [ "bitcoin_hashes" ] }
+secp256k1 = { version = "0.20.0", features = [ "bitcoin_hashes" ] }
 secp256k1-zkp = { git = "https://github.com/comit-network/rust-secp256k1-zkp", features = [ "use-serde", "global-context", "hashes" ] }
 serde-crate = { package = "serde", version = "1", optional = true, features = [ "derive" ] } # Used for ContractHash::from_json_contract.
 serde_json = { version = "1", optional = true }

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 elements-fun = { path = "../elements-fun", features = [ "serde" ] }
-secp256k1 = { version = "0.19.0", features = [ "bitcoin_hashes" ] }
+secp256k1 = { version = "0.20.0", features = [ "bitcoin_hashes", "rand" ] }
 serde = { version = "1", features = [ "derive" ] }
 sha2 = "0.9"
 


### PR DESCRIPTION
Most notably, we remove patching of reqwest and miniscript but also
update to the latest HEAD of secp256k1-zkp which now depends on
secp256k1 0.20