### PR TITLE
Update bobtimus api and extract helper in waves

### DIFF
--- a/bobtimus/src/bin/fake_bobtimus.rs
+++ b/bobtimus/src/bin/fake_bobtimus.rs
@@ -43,9 +43,7 @@ async fn main() -> Result<()> {
     let cors = warp::cors().allow_any_origin();
 
     let faucet = warp::post()
-        .and(warp::path!("api" / "faucet" / ..))
-        .and(warp::path::param())
-        .and(warp::path::end())
+        .and(warp::path!("api" / "faucet" / Address))
         .and(bobtimus_filter)
         .and_then(faucet);
 

--- a/bobtimus/src/bin/fake_bobtimus.rs
+++ b/bobtimus/src/bin/fake_bobtimus.rs
@@ -39,6 +39,9 @@ async fn main() -> Result<()> {
         let bobtimus = bobtimus.clone();
         move || bobtimus.clone()
     });
+
+    let cors = warp::cors().allow_any_origin();
+
     let faucet = warp::post()
         .and(warp::path("faucet"))
         .and(warp::path::param())
@@ -46,7 +49,7 @@ async fn main() -> Result<()> {
         .and(bobtimus_filter)
         .and_then(faucet);
 
-    warp::serve(routes.or(faucet))
+    warp::serve(routes.or(faucet).with(cors))
         .run(([127, 0, 0, 1], api_port))
         .await;
 

--- a/bobtimus/src/bin/fake_bobtimus.rs
+++ b/bobtimus/src/bin/fake_bobtimus.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     let cors = warp::cors().allow_any_origin();
 
     let faucet = warp::post()
-        .and(warp::path("faucet"))
+        .and(warp::path!("api" / "faucet" / ..))
         .and(warp::path::param())
         .and(warp::path::end())
         .and(bobtimus_filter)

--- a/bobtimus/src/http.rs
+++ b/bobtimus/src/http.rs
@@ -34,7 +34,6 @@ where
     });
     let create_swap = warp::post()
         .and(warp::path!("api" / "swap" / "lbtc-lusdt" / "sell"))
-        .and(warp::path::end())
         .and(bobtimus_filter)
         .and(warp::body::json())
         .and_then(create_swap);

--- a/bobtimus/src/http.rs
+++ b/bobtimus/src/http.rs
@@ -24,7 +24,7 @@ where
     let index_html = warp::path::end().and_then(serve_index);
     let waves_resources = warp::path::tail().and_then(serve_waves_resources);
 
-    let latest_rate = warp::path!("rate" / "lbtc-lusdt")
+    let latest_rate = warp::path!("api" / "rate" / "lbtc-lusdt")
         .and(warp::get())
         .map(move || latest_rate(latest_rate_subscription.clone()));
 

--- a/waves/src/Bobtimus.tsx
+++ b/waves/src/Bobtimus.tsx
@@ -1,0 +1,34 @@
+import React, { ReactElement } from "react";
+import { SSEProvider } from "react-hooks-sse";
+import { CreateSwapPayload } from "./wasmProxy";
+
+export async function fundAddress(address: string): Promise<any> {
+    await fetch("/api/faucet/" + address, {
+        method: "POST",
+    });
+}
+
+export async function postSellPayload(payload: CreateSwapPayload) {
+    let res = await fetch("/api/swap/lbtc-lusdt/sell", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+        body: JSON.stringify(payload),
+    });
+    console.log(res);
+    return (await res.json()) as {};
+}
+
+interface RateProviderProps {
+    children: ReactElement;
+}
+
+export function BobtimusRateProvider({ children }: RateProviderProps) {
+    return (
+        <SSEProvider endpoint="/api/rate/lbtc-lusdt">
+            {children}
+        </SSEProvider>
+    );
+}

--- a/waves/src/Bobtimus.tsx
+++ b/waves/src/Bobtimus.tsx
@@ -17,7 +17,6 @@ export async function postSellPayload(payload: CreateSwapPayload) {
         },
         body: JSON.stringify(payload),
     });
-    console.log(res);
     return (await res.json()) as {};
 }
 

--- a/waves/src/SwapWithWallet.tsx
+++ b/waves/src/SwapWithWallet.tsx
@@ -20,6 +20,7 @@ import {
 import React, { Dispatch, MouseEvent, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { Action, AssetType } from "./App";
+import { postSellPayload } from "./Bobtimus";
 import Bitcoin from "./components/bitcoin.svg";
 import Usdt from "./components/tether.svg";
 import { makeCreateSwapPayload } from "./wasmProxy";
@@ -64,18 +65,8 @@ function SwapWithWallet({
 
     const fetchSwapTransaction = async () => {
         let payload = await makeCreateSwapPayload(alphaAmount.toString());
+        let tx = await postSellPayload(payload);
 
-        let res = await fetch("/api/swap/lbtc-lusdt/sell", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Accept: "application/json",
-            },
-            body: JSON.stringify(payload),
-        });
-        console.log(res);
-
-        let tx = (await res.json()) as {};
         setTransaction(tx);
 
         console.log(JSON.stringify(transaction));

--- a/waves/src/WalletInfo.tsx
+++ b/waves/src/WalletInfo.tsx
@@ -20,6 +20,7 @@ import QRCode from "qrcode.react";
 import React, { ChangeEvent } from "react";
 import { Async } from "react-async";
 import { WalletBalance } from "./App";
+import { fundAddress } from "./Bobtimus";
 import Btc from "./components/bitcoin.svg";
 import Usdt from "./components/tether.svg";
 import { getAddress, withdrawAll } from "./wasmProxy";
@@ -42,9 +43,7 @@ export default function WalletInfo({ balance }: WalletInfoProps) {
 
     async function fundWallet(): Promise<any> {
         let address = await getAddress();
-        await fetch("/faucet/" + address, {
-            method: "POST",
-        });
+        await fundAddress(address);
     }
 
     return (

--- a/waves/src/index.tsx
+++ b/waves/src/index.tsx
@@ -1,8 +1,8 @@
 import { ChakraProvider } from "@chakra-ui/react";
 import React from "react";
 import ReactDOM from "react-dom";
-import { SSEProvider } from "react-hooks-sse";
 import App from "./App";
+import { BobtimusRateProvider } from "./Bobtimus";
 import "./index.css";
 import reportWebVitals from "./reportWebVitals";
 import theme from "./theme";
@@ -10,9 +10,7 @@ import theme from "./theme";
 ReactDOM.render(
     <React.StrictMode>
         <ChakraProvider theme={theme}>
-            <SSEProvider endpoint="/rate/lbtc-lusdt">
-                <App />
-            </SSEProvider>
+            <BobtimusRateProvider children={<App />} />
         </ChakraProvider>
     </React.StrictMode>,
     document.getElementById("root"),

--- a/waves/src/index.tsx
+++ b/waves/src/index.tsx
@@ -10,7 +10,9 @@ import theme from "./theme";
 ReactDOM.render(
     <React.StrictMode>
         <ChakraProvider theme={theme}>
-            <BobtimusRateProvider children={<App />} />
+            <BobtimusRateProvider>
+                <App />
+            </BobtimusRateProvider>
         </ChakraProvider>
     </React.StrictMode>,
     document.getElementById("root"),


### PR DESCRIPTION
This PR adds `api` prefix to all Bobtimus API. I've extracted a helper file `Bobtimus.tsx` in waves which should serve as a onestop place to interact with Bobtimus.

It also enables all cors headers for `fake_bobtimus` which simplifies development. 

Resolves #77 