### PR TITLE
Decompose Bob's transaction into our unblinded inputs and outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 
 [[package]]
+name = "bincode"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+dependencies = [
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "bitcoin"
 version = "0.25.2"
 source = "git+https://github.com/thomaseizinger/rust-bitcoin?branch=secp-0.20-rust-bitcoin-0.25.2#3751b736f28c9960bb8a8172e29fe0a2688bb868"
@@ -246,6 +256,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "elements-fun",
  "elements-harness",
  "env_logger",

--- a/bobtimus/src/http.rs
+++ b/bobtimus/src/http.rs
@@ -66,7 +66,7 @@ where
         .await
         .map(|transaction| serialize_hex(&transaction))
         .map_err(|e| {
-            log::error!("{}", e);
+            log::error!("Failed to handle create swap: {}", e);
             warp::reject::reject()
         })
 }

--- a/elements-fun/src/lib.rs
+++ b/elements-fun/src/lib.rs
@@ -63,5 +63,5 @@ pub use script::Script;
 pub use transaction::{
     AssetIssuance, ConfidentialAssetIssuance, ConfidentialTxOut, ExplicitAsset,
     ExplicitAssetIssuance, ExplicitTxOut, ExplicitValue, OutPoint, PeginData, PegoutData,
-    SigHashType, Transaction, TxIn, TxInWitness, TxOut, TxOutWitness, UnblindedTxOut,
+    SigHashType, Transaction, TxIn, TxInWitness, TxOut, TxOutWitness, UnblindError, UnblindedTxOut,
 };

--- a/waves/src/Bobtimus.tsx
+++ b/waves/src/Bobtimus.tsx
@@ -17,7 +17,8 @@ export async function postSellPayload(payload: CreateSwapPayload) {
         },
         body: JSON.stringify(payload),
     });
-    return (await res.json()) as {};
+
+    return await res.text();
 }
 
 interface RateProviderProps {
@@ -25,9 +26,5 @@ interface RateProviderProps {
 }
 
 export function BobtimusRateProvider({ children }: RateProviderProps) {
-    return (
-        <SSEProvider endpoint="/api/rate/lbtc-lusdt">
-            {children}
-        </SSEProvider>
-    );
+    return <SSEProvider endpoint="/api/rate/lbtc-lusdt">{children}</SSEProvider>;
 }

--- a/waves/src/SwapWithWallet.tsx
+++ b/waves/src/SwapWithWallet.tsx
@@ -23,7 +23,7 @@ import { Action, AssetType } from "./App";
 import { postSellPayload } from "./Bobtimus";
 import Bitcoin from "./components/bitcoin.svg";
 import Usdt from "./components/tether.svg";
-import { makeCreateSellSwapPayload } from "./wasmProxy";
+import { decomposeTransaction, makeCreateSellSwapPayload, TransactionElements } from "./wasmProxy";
 
 interface SwapWithWalletProps {
     alphaAmount: number;
@@ -44,7 +44,12 @@ function SwapWithWallet({
     onConfirmed,
     dispatch,
 }: SwapWithWalletProps) {
-    const [transaction, setTransaction] = useState({});
+    // eslint-disable-next-line
+    const [transaction, setTransaction] = useState("");
+    // eslint-disable-next-line
+    const [transactionElements, setTransactionElements] = useState<
+        TransactionElements | undefined
+    >(undefined);
     const { isOpen, onOpen, onClose } = useDisclosure();
     const btnRef = React.useRef(null);
     const history = useHistory();
@@ -69,7 +74,10 @@ function SwapWithWallet({
 
         setTransaction(tx);
 
-        console.log(JSON.stringify(transaction));
+        let elements = await decomposeTransaction(tx);
+        setTransactionElements(elements);
+
+        console.log("Transaction elements: " + JSON.stringify(elements));
 
         onOpen();
     };

--- a/waves/src/wasmProxy.ts
+++ b/waves/src/wasmProxy.ts
@@ -17,6 +17,11 @@ export interface CreateSwapPayload {
     btc_amount: number;
 }
 
+export interface TransactionElements {
+    our_inputs: [string, number][];
+    our_outputs: [string, number][];
+}
+
 const WALLET_NAME = "wallet-1";
 
 export async function getAddress() {
@@ -59,4 +64,11 @@ export async function makeCreateSellSwapPayload(
 ): Promise<CreateSwapPayload> {
     const { make_create_sell_swap_payload } = await import("./wallet");
     return make_create_sell_swap_payload(WALLET_NAME, btc);
+}
+
+export async function decomposeTransaction(
+    transaction: string,
+): Promise<TransactionElements> {
+    const { decompose_transaction } = await import("./wallet");
+    return decompose_transaction(WALLET_NAME, transaction);
 }

--- a/waves/wallet/src/wallet.rs
+++ b/waves/wallet/src/wallet.rs
@@ -29,6 +29,7 @@ use std::{fmt, str};
 use wasm_bindgen::{JsValue, UnwrapThrowExt};
 
 pub use create_new::create_new;
+pub use decompose_transaction::decompose_transaction;
 pub use get_address::get_address;
 pub use get_balances::get_balances;
 pub use get_status::get_status;
@@ -40,6 +41,7 @@ pub use withdraw_everything_to::withdraw_everything_to;
 
 mod coin_selection;
 mod create_new;
+mod decompose_transaction;
 mod get_address;
 mod get_balances;
 mod get_status;

--- a/waves/wallet/src/wallet/decompose_transaction.rs
+++ b/waves/wallet/src/wallet/decompose_transaction.rs
@@ -1,0 +1,74 @@
+use crate::wallet::{current, get_txouts, Wallet};
+use anyhow::{Context, Result};
+use elements_fun::{secp256k1::SECP256K1, AssetId, Transaction, TxOut, UnblindError};
+use futures::lock::Mutex;
+use serde::Serialize;
+use wasm_bindgen::JsValue;
+
+#[derive(Serialize)]
+pub struct TransactionElements {
+    our_inputs: Vec<(AssetId, u64)>,
+    our_outputs: Vec<(AssetId, u64)>,
+}
+
+pub async fn decompose_transaction(
+    name: String,
+    current_wallet: &Mutex<Option<Wallet>>,
+    transaction: Transaction,
+) -> Result<TransactionElements, JsValue> {
+    let wallet = current(&name, current_wallet).await?;
+    let blinding_key = wallet.blinding_key();
+
+    let our_inputs = get_txouts(&wallet, |utxo, ref txout| {
+        transaction
+            .input
+            .iter()
+            .find_map(|txin| {
+                if utxo.txid == txin.previous_output.txid && utxo.vout == txin.previous_output.vout
+                {
+                    match txout {
+                        TxOut::Explicit(txout) => Some(Ok((txout.asset.0, txout.value.0))),
+                        TxOut::Confidential(confidential) => Some(
+                            confidential
+                                .unblind(SECP256K1, blinding_key)
+                                .map(|unblinded| (unblinded.asset, unblinded.value)),
+                        ),
+                        TxOut::Null(_) => None,
+                    }
+                } else {
+                    None
+                }
+            })
+            .transpose()
+            .context("failed to unblind one of our inputs")
+    })
+    .await?;
+
+    let our_address = wallet.get_address()?;
+    let our_outputs = map_err_from_anyhow!(transaction
+        .output
+        .iter()
+        .filter_map(|txout| match txout {
+            TxOut::Explicit(txout) if txout.script_pubkey == our_address.script_pubkey() =>
+                Some(Ok((txout.asset.0, txout.value.0))),
+            TxOut::Confidential(confidential) => {
+                match confidential.unblind(SECP256K1, blinding_key) {
+                    Ok(unblinded) => Some(Ok((unblinded.asset, unblinded.value))),
+                    _ => None,
+                }
+            }
+            TxOut::Explicit(_) => {
+                log::debug!(
+                    "ignoring explicit outputs that do not pay to our address, including fees"
+                );
+                None
+            }
+            TxOut::Null(_) => None,
+        })
+        .collect::<Result<Vec<_>, UnblindError>>())?;
+
+    Ok(TransactionElements {
+        our_inputs,
+        our_outputs,
+    })
+}


### PR DESCRIPTION
I decided to change the serialisation format for the transaction because deserialising the JSON was failing on waves wallet. I could not reproduce the error via unit tests ("malformed pedersen commitment") so I went for a quick fix. It may be worth it to get to bottom of it.