### PR TITLE
Point user to local blockexplorer instead of blockstream.info on regtest

### DIFF
--- a/waves-scripts
+++ b/waves-scripts
@@ -101,12 +101,13 @@ start_frontend () {
 
     __read_env_file
 
-    local -r chopsticks_url="http://127.0.0.1:$LIQUID_CHOPSTICKS_PORT"
     cd waves
     yarn install
     export NATIVE_ASSET_ID=$(nigiri rpc --liquid dumpassetlabels | jq -r '.bitcoin')
     export CHAIN=ELEMENTS
-    export ESPLORA_API_URL=$chopsticks_url
+    export ESPLORA_API_URL=$LIQUID_ESPLORA_URL
+    export REACT_APP_BLOCKEXPLORER_URL="http://localhost:$LIQUID_ESPLORA_PORT"
+
     yarn start
 }
 

--- a/waves/src/App.tsx
+++ b/waves/src/App.tsx
@@ -350,9 +350,12 @@ function App() {
 
 function BlockExplorerLink() {
     const { txId } = useParams<{ txId: string }>();
+    const baseUrl = process.env.REACT_APP_BLOCKEXPLORER_URL
+        ? `${process.env.REACT_APP_BLOCKEXPLORER_URL}`
+        : "https://blockstream.info/liquid";
 
     return <Link
-        href={`https://blockstream.info/liquid/tx/${txId}`}
+        href={`${baseUrl}/tx/${txId}`}
         isExternal
     >
         Block Explorer <ExternalLinkIcon mx="2px" />


### PR DESCRIPTION
Fixes #89.