### PR TITLE
Stop making too many evil clones of Bob

### DIFF
--- a/bobtimus/src/lib.rs
+++ b/bobtimus/src/lib.rs
@@ -27,7 +27,6 @@ pub use amounts::*;
 
 pub const USDT_ASSET_ID: &str = "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2";
 
-#[derive(Clone)]
 pub struct Bobtimus<R, RS> {
     pub rng: R,
     pub rate_service: RS,


### PR DESCRIPTION
Bobtimus holds an instance of rng initialised at start-up. Every time we receive a request, we clone our instance of Bobtimus and therefore the instance of rng itself. Any state changes to the rng (which happen during usage) thereby did not affect the original prototype of Bobtimus. As a result, any future request started with exactly the same rng state and therefore produced the same sequence of random numbers.

This led to conflicting blinding factors between inputs and outputs.

Fixes #91.