### PR TITLE
Serve frontend under /app namespace

### DIFF
--- a/bobtimus/src/http.rs
+++ b/bobtimus/src/http.rs
@@ -24,11 +24,14 @@ where
     R: RngCore + CryptoRng + Clone + Send + Sync + 'static,
     RS: LatestRate + Clone + Send + Sync + 'static,
 {
-    let index_html = warp::path::end().and_then(serve_index);
-    let waves_resources = warp::path::tail().and_then(serve_waves_resources);
+    let index_html = warp::get().and(warp::path::end()).and_then(serve_index);
+    let waves_resources = warp::get()
+        .and(warp::path("app"))
+        .and(warp::path::tail())
+        .and_then(serve_waves_resources);
 
-    let latest_rate = warp::path!("api" / "rate" / "lbtc-lusdt")
-        .and(warp::get())
+    let latest_rate = warp::get()
+        .and(warp::path!("api" / "rate" / "lbtc-lusdt"))
         .map(move || latest_rate(latest_rate_subscription.clone()));
 
     let create_swap = warp::post()

--- a/waves/package.json
+++ b/waves/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "proxy": "http://localhost:3030",
+  "homepage": "/app",
   "dependencies": {
     "@chakra-ui/icons": "^1.0.1",
     "@chakra-ui/react": "^1.0.1",

--- a/waves/src/App.tsx
+++ b/waves/src/App.tsx
@@ -1,6 +1,6 @@
 import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { Box, Button, Center, Flex, Link, Text, useDisclosure, VStack } from "@chakra-ui/react";
-import React, { useReducer, useState } from "react";
+import React, { useEffect, useReducer, useState } from "react";
 import { useAsync } from "react-async";
 import { useSSE } from "react-hooks-sse";
 import { Route, Switch, useHistory, useParams } from "react-router-dom";
@@ -168,6 +168,14 @@ export function reducer(state: State = initialState, action: Action) {
 
 function App() {
     const history = useHistory();
+    const path = history.location.pathname;
+
+    useEffect(() => {
+        if (path === "/app") {
+            history.replace("/");
+        }
+    }, [path, history]);
+
     const [[transaction, trade], setTransaction] = useState<[string, Trade]>(["", {} as any]);
     const [state, dispatch] = useReducer(reducer, initialState);
 


### PR DESCRIPTION
This applies to all assets apart from index.html.

Unfortunately, we need to add a hook to the app to redirect from
/app to / to make it work with the webpack-dev-server because
setting `homepage` in `package.json` makes `react-scripts` open
the browser on `http://localhost:3004/app`.

I hesitated to guard this piece of code with `if env == development`
because I think it might actually also be useful in production.
If someone for whatever reasons investigates our routes and finds
`/app`, we just send them back to the root.

Resolves #79.